### PR TITLE
feat(types): add TypeScript types and data models

### DIFF
--- a/src/types/attribute.ts
+++ b/src/types/attribute.ts
@@ -1,0 +1,14 @@
+export type AttributeCategory = 'dealbreaker' | 'desired';
+
+export interface Attribute {
+  id: string;
+  name: string;
+  category: AttributeCategory;
+  createdAt: Date;
+  order: number;
+}
+
+export interface AttributeInput {
+  name: string;
+  category: AttributeCategory;
+}

--- a/src/types/compatibility.ts
+++ b/src/types/compatibility.ts
@@ -1,0 +1,18 @@
+export interface CompatibilityScore {
+  overall: number; // 0-100
+  dealbreakersScore: number; // 0-100
+  desiredScore: number; // 0-100
+  unknownCount: number;
+  confirmedYesCount: number;
+  confirmedNoCount: number;
+  dealbreakersWithNo: string[]; // Names of dealbreaker traits marked "no"
+}
+
+export interface ScoreBreakdown {
+  category: 'dealbreaker' | 'desired';
+  total: number;
+  confirmed: number;
+  yesCount: number;
+  noCount: number;
+  score: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,15 @@
-export {};
+export type { UserSettings, UserProfile } from './user';
+export type {
+  AttributeCategory,
+  Attribute,
+  AttributeInput,
+} from './attribute';
+export type {
+  ProspectStatus,
+  TraitState,
+  Trait,
+  DateEntry,
+  Prospect,
+  ProspectInput,
+} from './prospect';
+export type { CompatibilityScore, ScoreBreakdown } from './compatibility';

--- a/src/types/prospect.ts
+++ b/src/types/prospect.ts
@@ -1,0 +1,43 @@
+import { AttributeCategory } from './attribute';
+
+export type ProspectStatus = 'talking' | 'dating' | 'archived' | 'relationship';
+export type TraitState = 'unknown' | 'yes' | 'no';
+
+export interface Trait {
+  id: string;
+  attributeId: string;
+  attributeName: string; // Denormalized for display
+  attributeCategory: AttributeCategory;
+  state: TraitState;
+  updatedAt: Date;
+}
+
+export interface DateEntry {
+  id: string;
+  date: Date;
+  location?: string;
+  notes?: string;
+  rating?: number; // 1-5 optional
+  createdAt: Date;
+}
+
+export interface Prospect {
+  id: string;
+  name: string;
+  photoUri?: string;
+  status: ProspectStatus;
+  howWeMet?: string;
+  notes?: string;
+  traits: Trait[];
+  dates: DateEntry[];
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt?: Date;
+}
+
+export interface ProspectInput {
+  name: string;
+  photoUri?: string;
+  howWeMet?: string;
+  hasMetInPerson: boolean; // Determines initial status
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,18 @@
+export interface UserSettings {
+  scoringStrictness: 'gentle' | 'normal' | 'strict';
+  notificationsEnabled: boolean;
+  quietHoursStart: string;
+  quietHoursEnd: string;
+  recapFrequency: 'weekly' | 'biweekly' | 'monthly';
+  appLockEnabled: boolean;
+  appLockTimeout: number;
+  biometricEnabled: boolean;
+}
+
+export interface UserProfile {
+  id: string;
+  displayName: string;
+  email: string;
+  createdAt: Date;
+  settings: UserSettings;
+}


### PR DESCRIPTION
## Summary

Define all TypeScript types and interfaces for the application data model per spec Section 5.2.

## Files

- `src/types/user.ts` — UserSettings, UserProfile
- `src/types/attribute.ts` — AttributeCategory, Attribute, AttributeInput
- `src/types/prospect.ts` — ProspectStatus, TraitState, Trait, DateEntry, Prospect, ProspectInput
- `src/types/compatibility.ts` — CompatibilityScore, ScoreBreakdown
- `src/types/index.ts` — Barrel export

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Types match spec exactly
- [x] Barrel export allows `import { Prospect, Trait } from '@/types'`

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)