### PR TITLE
Replace used suggestion with new one when attribute is tap-added

### DIFF
--- a/src/components/onboarding/AttributesStep.tsx
+++ b/src/components/onboarding/AttributesStep.tsx
@@ -27,6 +27,7 @@ export const AttributesStep = ({ onNext, onBack }: AttributesStepProps) => {
     suggestions,
     hasMinimumAttributes,
     addAttribute,
+    addAttributeFromSuggestion,
     removeAttribute,
     refreshSuggestions,
   } = useAttributes();
@@ -41,7 +42,7 @@ export const AttributesStep = ({ onNext, onBack }: AttributesStepProps) => {
   };
 
   const handleSuggestionPress = async (name: string) => {
-    await addAttribute(name, 'desired');
+    await addAttributeFromSuggestion(name, 'desired');
   };
 
   return (

--- a/src/components/onboarding/__tests__/AttributesStep.test.tsx
+++ b/src/components/onboarding/__tests__/AttributesStep.test.tsx
@@ -15,6 +15,7 @@ jest.mock('react-native-safe-area-context', () => ({
 }));
 
 const mockAddAttribute = jest.fn();
+const mockAddAttributeFromSuggestion = jest.fn();
 const mockRemoveAttribute = jest.fn();
 const mockRefreshSuggestions = jest.fn();
 
@@ -28,6 +29,7 @@ jest.mock('@/hooks', () => ({
     suggestions: ['Ambitious', 'Loyal', 'Patient'],
     hasMinimumAttributes: true,
     addAttribute: mockAddAttribute,
+    addAttributeFromSuggestion: mockAddAttributeFromSuggestion,
     removeAttribute: mockRemoveAttribute,
     refreshSuggestions: mockRefreshSuggestions,
     toggleCategory: jest.fn(),
@@ -67,12 +69,12 @@ describe('AttributesStep', () => {
     expect(getByText('Patient')).toBeTruthy();
   });
 
-  it('calls addAttribute when suggestion chip is pressed', () => {
+  it('calls addAttributeFromSuggestion when suggestion chip is pressed', () => {
     const { getByText } = render(
       <AttributesStep onNext={jest.fn()} onBack={jest.fn()} />
     );
     fireEvent.press(getByText('Ambitious'));
-    expect(mockAddAttribute).toHaveBeenCalledWith('Ambitious', 'desired');
+    expect(mockAddAttributeFromSuggestion).toHaveBeenCalledWith('Ambitious', 'desired');
   });
 
   it('calls onNext when Next is pressed', () => {


### PR DESCRIPTION
## Summary
- Add `replaceSuggestion` helper to swap a used suggestion chip with a new random preset
- Add `addAttributeFromSuggestion` that adds the attribute then immediately replaces the suggestion
- Update `AttributesStep` to use the new function for suggestion chip taps
- Keeps suggestion list full and fresh as users add attributes

## Test plan
- [x] All 59 tests pass
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [ ] Manual test: tap suggestion → chip is replaced with new suggestion

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)