### PR TITLE
Scope PIN and lock settings to user account

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -33,20 +33,20 @@ const AppContent = () => {
 };
 
 const AuthGate = () => {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
 
   // While checking auth state, render nothing (splash screen covers this)
   if (isLoading) {
     return null;
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated || !user) {
     return <AuthScreen />;
   }
 
   // Authenticated → app lock check → attributes → main app
   return (
-    <AppLockProvider>
+    <AppLockProvider userId={user.uid}>
       <AttributesProvider>
         <AppContent />
       </AttributesProvider>

--- a/src/services/storage/__tests__/secureStorage.test.ts
+++ b/src/services/storage/__tests__/secureStorage.test.ts
@@ -10,15 +10,17 @@ import {
   getBiometricEnabled,
 } from '@/services/storage/secureStorage';
 
+const TEST_USER_ID = 'test-user-123';
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe('PIN storage', () => {
-  it('stores a hashed PIN', async () => {
-    await storePinHash('1234');
+  it('stores a hashed PIN scoped to user', async () => {
+    await storePinHash(TEST_USER_ID, '1234');
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
-      'pinHash',
+      `${TEST_USER_ID}_pinHash`,
       expect.any(String)
     );
     // Hash should not be the raw PIN
@@ -26,89 +28,110 @@ describe('PIN storage', () => {
     expect(storedHash).not.toBe('1234');
   });
 
-  it('retrieves a stored PIN hash', async () => {
+  it('retrieves a stored PIN hash for user', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('somehash');
-    const hash = await getPinHash();
+    const hash = await getPinHash(TEST_USER_ID);
     expect(hash).toBe('somehash');
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith(`${TEST_USER_ID}_pinHash`);
   });
 
   it('returns null when no PIN is stored', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
-    const hash = await getPinHash();
+    const hash = await getPinHash(TEST_USER_ID);
     expect(hash).toBeNull();
   });
 
   it('verifies correct PIN returns true', async () => {
     // Store a PIN, then verify it
-    await storePinHash('5678');
+    await storePinHash(TEST_USER_ID, '5678');
     const storedHash = (SecureStore.setItemAsync as jest.Mock).mock.calls[0][1];
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(storedHash);
 
-    const result = await verifyPin('5678');
+    const result = await verifyPin(TEST_USER_ID, '5678');
     expect(result).toBe(true);
   });
 
   it('verifies wrong PIN returns false', async () => {
-    await storePinHash('5678');
+    await storePinHash(TEST_USER_ID, '5678');
     const storedHash = (SecureStore.setItemAsync as jest.Mock).mock.calls[0][1];
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(storedHash);
 
-    const result = await verifyPin('0000');
+    const result = await verifyPin(TEST_USER_ID, '0000');
     expect(result).toBe(false);
   });
 
   it('returns false when no PIN is stored', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
-    const result = await verifyPin('1234');
+    const result = await verifyPin(TEST_USER_ID, '1234');
     expect(result).toBe(false);
   });
 
-  it('clears stored PIN hash', async () => {
-    await clearPinHash();
-    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('pinHash');
+  it('clears stored PIN hash for user', async () => {
+    await clearPinHash(TEST_USER_ID);
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(`${TEST_USER_ID}_pinHash`);
+  });
+
+  it('isolates PINs between users', async () => {
+    const user1 = 'user-1';
+    const user2 = 'user-2';
+
+    // Store PIN for user1
+    await storePinHash(user1, '1111');
+    const user1Hash = (SecureStore.setItemAsync as jest.Mock).mock.calls[0][1];
+
+    // Store PIN for user2
+    await storePinHash(user2, '2222');
+    const user2Hash = (SecureStore.setItemAsync as jest.Mock).mock.calls[1][1];
+
+    // Verify keys are different
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(`${user1}_pinHash`, user1Hash);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(`${user2}_pinHash`, user2Hash);
+    expect(user1Hash).not.toBe(user2Hash);
   });
 });
 
 describe('app lock preference', () => {
-  it('stores app lock enabled state', async () => {
-    await setAppLockEnabled(true);
+  it('stores app lock enabled state scoped to user', async () => {
+    await setAppLockEnabled(TEST_USER_ID, true);
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
-      'appLockEnabled',
+      `${TEST_USER_ID}_appLockEnabled`,
       'true'
     );
   });
 
-  it('retrieves app lock enabled state', async () => {
+  it('retrieves app lock enabled state for user', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('true');
-    const result = await getAppLockEnabled();
+    const result = await getAppLockEnabled(TEST_USER_ID);
     expect(result).toBe(true);
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith(`${TEST_USER_ID}_appLockEnabled`);
   });
 
   it('defaults to false when not set', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
-    const result = await getAppLockEnabled();
+    const result = await getAppLockEnabled(TEST_USER_ID);
     expect(result).toBe(false);
   });
 });
 
 describe('biometric preference', () => {
-  it('stores biometric enabled state', async () => {
-    await setBiometricEnabled(true);
+  it('stores biometric enabled state scoped to user', async () => {
+    await setBiometricEnabled(TEST_USER_ID, true);
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
-      'biometricEnabled',
+      `${TEST_USER_ID}_biometricEnabled`,
       'true'
     );
   });
 
-  it('retrieves biometric enabled state', async () => {
+  it('retrieves biometric enabled state for user', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce('false');
-    const result = await getBiometricEnabled();
+    const result = await getBiometricEnabled(TEST_USER_ID);
     expect(result).toBe(false);
+    expect(SecureStore.getItemAsync).toHaveBeenCalledWith(`${TEST_USER_ID}_biometricEnabled`);
   });
 
   it('defaults to false when not set', async () => {
     (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
-    const result = await getBiometricEnabled();
+    const result = await getBiometricEnabled(TEST_USER_ID);
     expect(result).toBe(false);
   });
 });

--- a/src/services/storage/asyncStorage.ts
+++ b/src/services/storage/asyncStorage.ts
@@ -1,52 +1,53 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const LOCK_TIMEOUT_KEY = 'appLockTimeout';
-const LAST_ACTIVE_KEY = 'lastActiveTimestamp';
+// Key generators - scope all lock settings to user ID
+const getLockTimeoutKey = (userId: string) => `${userId}_appLockTimeout`;
+const getLastActiveKey = (userId: string) => `${userId}_lastActiveTimestamp`;
 
 /**
  * Store the app lock timeout preference (in minutes)
  */
-export const setLockTimeout = async (minutes: number): Promise<void> => {
-  await AsyncStorage.setItem(LOCK_TIMEOUT_KEY, JSON.stringify(minutes));
+export const setLockTimeout = async (userId: string, minutes: number): Promise<void> => {
+  await AsyncStorage.setItem(getLockTimeoutKey(userId), JSON.stringify(minutes));
 };
 
 /**
  * Get the app lock timeout preference (defaults to 10 minutes)
  */
-export const getLockTimeout = async (): Promise<number> => {
-  const value = await AsyncStorage.getItem(LOCK_TIMEOUT_KEY);
+export const getLockTimeout = async (userId: string): Promise<number> => {
+  const value = await AsyncStorage.getItem(getLockTimeoutKey(userId));
   return value ? JSON.parse(value) : 10;
 };
 
 /**
  * Store the last active timestamp (when app went to background)
  */
-export const setLastActiveTimestamp = async (): Promise<void> => {
-  await AsyncStorage.setItem(LAST_ACTIVE_KEY, JSON.stringify(Date.now()));
+export const setLastActiveTimestamp = async (userId: string): Promise<void> => {
+  await AsyncStorage.setItem(getLastActiveKey(userId), JSON.stringify(Date.now()));
 };
 
 /**
  * Get the last active timestamp
  */
-export const getLastActiveTimestamp = async (): Promise<number | null> => {
-  const value = await AsyncStorage.getItem(LAST_ACTIVE_KEY);
+export const getLastActiveTimestamp = async (userId: string): Promise<number | null> => {
+  const value = await AsyncStorage.getItem(getLastActiveKey(userId));
   return value ? JSON.parse(value) : null;
 };
 
 /**
  * Clear the last active timestamp
  */
-export const clearLastActiveTimestamp = async (): Promise<void> => {
-  await AsyncStorage.removeItem(LAST_ACTIVE_KEY);
+export const clearLastActiveTimestamp = async (userId: string): Promise<void> => {
+  await AsyncStorage.removeItem(getLastActiveKey(userId));
 };
 
 /**
  * Check if the lock timeout has elapsed since last active
  */
-export const hasLockTimeoutElapsed = async (): Promise<boolean> => {
+export const hasLockTimeoutElapsed = async (userId: string): Promise<boolean> => {
   const [lastActive, timeout] = await Promise.all([
-    getLastActiveTimestamp(),
-    getLockTimeout(),
+    getLastActiveTimestamp(userId),
+    getLockTimeout(userId),
   ]);
   if (!lastActive) return true;
 

--- a/src/services/storage/secureStorage.ts
+++ b/src/services/storage/secureStorage.ts
@@ -1,9 +1,10 @@
 import * as SecureStore from 'expo-secure-store';
 import * as Crypto from 'expo-crypto';
 
-const PIN_HASH_KEY = 'pinHash';
-const APP_LOCK_ENABLED_KEY = 'appLockEnabled';
-const BIOMETRIC_ENABLED_KEY = 'biometricEnabled';
+// Key generators - scope all lock settings to user ID
+const getPinHashKey = (userId: string) => `${userId}_pinHash`;
+const getAppLockEnabledKey = (userId: string) => `${userId}_appLockEnabled`;
+const getBiometricEnabledKey = (userId: string) => `${userId}_biometricEnabled`;
 
 /**
  * Hash a PIN using SHA-256
@@ -17,23 +18,23 @@ export const hashPin = async (pin: string): Promise<string> => {
 /**
  * Store hashed PIN in device SecureStore (never sent to cloud)
  */
-export const storePinHash = async (pin: string): Promise<void> => {
+export const storePinHash = async (userId: string, pin: string): Promise<void> => {
   const hash = await hashPin(pin);
-  await SecureStore.setItemAsync(PIN_HASH_KEY, hash);
+  await SecureStore.setItemAsync(getPinHashKey(userId), hash);
 };
 
 /**
- * Get stored PIN hash
+ * Get stored PIN hash for a user
  */
-export const getPinHash = async (): Promise<string | null> => {
-  return SecureStore.getItemAsync(PIN_HASH_KEY);
+export const getPinHash = async (userId: string): Promise<string | null> => {
+  return SecureStore.getItemAsync(getPinHashKey(userId));
 };
 
 /**
  * Verify a PIN against the stored hash
  */
-export const verifyPin = async (pin: string): Promise<boolean> => {
-  const storedHash = await getPinHash();
+export const verifyPin = async (userId: string, pin: string): Promise<boolean> => {
+  const storedHash = await getPinHash(userId);
   if (!storedHash) return false;
 
   const inputHash = await hashPin(pin);
@@ -41,38 +42,38 @@ export const verifyPin = async (pin: string): Promise<boolean> => {
 };
 
 /**
- * Clear stored PIN hash
+ * Clear stored PIN hash for a user
  */
-export const clearPinHash = async (): Promise<void> => {
-  await SecureStore.deleteItemAsync(PIN_HASH_KEY);
+export const clearPinHash = async (userId: string): Promise<void> => {
+  await SecureStore.deleteItemAsync(getPinHashKey(userId));
 };
 
 /**
  * Store app lock enabled preference in SecureStore
  */
-export const setAppLockEnabled = async (enabled: boolean): Promise<void> => {
-  await SecureStore.setItemAsync(APP_LOCK_ENABLED_KEY, JSON.stringify(enabled));
+export const setAppLockEnabled = async (userId: string, enabled: boolean): Promise<void> => {
+  await SecureStore.setItemAsync(getAppLockEnabledKey(userId), JSON.stringify(enabled));
 };
 
 /**
  * Get app lock enabled preference
  */
-export const getAppLockEnabled = async (): Promise<boolean> => {
-  const value = await SecureStore.getItemAsync(APP_LOCK_ENABLED_KEY);
+export const getAppLockEnabled = async (userId: string): Promise<boolean> => {
+  const value = await SecureStore.getItemAsync(getAppLockEnabledKey(userId));
   return value ? JSON.parse(value) : false;
 };
 
 /**
  * Store biometric enabled preference in SecureStore
  */
-export const setBiometricEnabled = async (enabled: boolean): Promise<void> => {
-  await SecureStore.setItemAsync(BIOMETRIC_ENABLED_KEY, JSON.stringify(enabled));
+export const setBiometricEnabled = async (userId: string, enabled: boolean): Promise<void> => {
+  await SecureStore.setItemAsync(getBiometricEnabledKey(userId), JSON.stringify(enabled));
 };
 
 /**
  * Get biometric enabled preference
  */
-export const getBiometricEnabled = async (): Promise<boolean> => {
-  const value = await SecureStore.getItemAsync(BIOMETRIC_ENABLED_KEY);
+export const getBiometricEnabled = async (userId: string): Promise<boolean> => {
+  const value = await SecureStore.getItemAsync(getBiometricEnabledKey(userId));
   return value ? JSON.parse(value) : false;
 };


### PR DESCRIPTION
## Summary
- Scope all PIN and lock-related SecureStore/AsyncStorage keys to user UID
- Keys are now prefixed with `${userId}_` (e.g., `user123_pinHash`)
- Prevents new users from seeing lock screens for previous users on the same device
- Updated tests to verify user isolation

## Changes
- `secureStorage.ts`: All functions now take `userId` as first parameter
- `asyncStorage.ts`: All functions now take `userId` as first parameter  
- `AppLockContext.tsx`: Accepts `userId` prop, passes to storage functions
- `useAppLock.ts`: Gets `userId` from context, passes to storage functions
- `_layout.tsx`: Passes `user.uid` to `AppLockProvider`

## Test plan
- [ ] User A sets PIN → signs out → User B signs up → User B should NOT see lock screen
- [ ] User B sets own PIN → signs out → User A signs in → User A sees their own lock screen
- [ ] All 60 tests pass

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)