### PR TITLE
Fix biometric text overlapping toggle switch

### DIFF
--- a/src/components/onboarding/SecurityStep.tsx
+++ b/src/components/onboarding/SecurityStep.tsx
@@ -226,7 +226,7 @@ export const SecurityStep = ({ onComplete, onBack }: SecurityStepProps) => {
           <View style={styles.optionCard}>
             <View style={styles.optionRow}>
               <Ionicons name="finger-print" size={24} color={theme.colors.primary} />
-              <View>
+              <View style={styles.optionTextContainer}>
                 <Text style={styles.optionLabel}>{t('Enable Biometrics')}</Text>
                 <Text style={styles.optionHint}>
                   {t('Use fingerprint or face recognition to unlock')}
@@ -308,6 +308,10 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       gap: 12,
       flex: 1,
+    },
+    optionTextContainer: {
+      flex: 1,
+      flexShrink: 1,
     },
     optionLabel: {
       fontSize: theme.typography.fontSize.base,


### PR DESCRIPTION
## Summary
- Added `flex: 1` and `flexShrink: 1` to the text container in the biometric option card
- Text now wraps properly instead of extending behind the toggle switch

## Changes
- `SecurityStep.tsx`: Added `optionTextContainer` style and applied it to the biometric text wrapper

## Test plan
- [ ] View SecurityStep with PIN set and biometrics available
- [ ] Verify "Use fingerprint or face recognition to unlock" text doesn't overlap the toggle

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)