### PR TITLE
Fix white header/footer on home screen

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,11 +1,50 @@
-import { Tabs } from "expo-router";
+import { Tabs } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useThemeContext } from '@/theme';
 
 const TabsLayout = () => {
+  const { theme } = useThemeContext();
+
   return (
-    <Tabs>
-      <Tabs.Screen name="index" options={{ title: "Home" }} />
-      <Tabs.Screen name="archive" options={{ title: "Archive" }} />
-      <Tabs.Screen name="settings" options={{ title: "Settings" }} />
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: theme.colors.background,
+          borderTopColor: theme.colors.backgroundCard,
+          borderTopWidth: 1,
+        },
+        tabBarActiveTintColor: theme.colors.primary,
+        tabBarInactiveTintColor: theme.colors.textMuted,
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="home" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="archive"
+        options={{
+          title: 'Archive',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="archive" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="settings" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 };


### PR DESCRIPTION
## Summary
- Hide default Expo Router header with `headerShown: false`
- Style tab bar to use theme background color instead of white
- Add tab bar icons (Home, Archive, Settings)
- Set active/inactive tint colors from theme

## Test plan
- [ ] Open app and verify no white header area on home screen
- [ ] Verify tab bar has cream background (matches app theme)
- [ ] Verify tab icons display correctly
- [ ] Verify active tab is highlighted with primary color
- [ ] Test on device with notch - safe area should still work

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)