### PR TITLE
Fix white flash during screen transitions

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -28,6 +28,7 @@ const queryClient = new QueryClient({
 });
 
 const AppContent = () => {
+  const { theme } = useThemeContext();
   const { isLocked } = useAppLock();
   const { userProfile, refreshProfile } = useAuth();
 
@@ -43,6 +44,7 @@ const AppContent = () => {
     <Stack
       screenOptions={{
         headerShown: false,
+        contentStyle: { backgroundColor: theme.colors.background },
       }}
     />
   );


### PR DESCRIPTION
## Summary
- Add `contentStyle` with theme background color to Stack navigator
- Prevents white flash during navigation transitions by matching the container background to the app theme

## Changes
- `src/app/_layout.tsx` - Access theme in AppContent and set Stack's contentStyle background

## Test Plan
- [ ] Navigate between screens (Home → Prospect → Traits → back)
- [ ] Verify no white flash appears during transitions
- [ ] Test in both light and dark modes

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)