### PR TITLE
Fix white flash during screen transitions (v2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ src/
 
 ## Workflow Rules
 
+- **Never commit directly to main** - Always create a new branch for changes, associated with the most closely related issue (e.g., `fix/issue-74-white-flash` or `feature/issue-18-trait-evaluation`)
 - **Never merge PRs without explicit permission** - Always wait for the user to say "merge it" or similar before merging
 - **Don't ask for confirmation to create issues** - Just create them when needed
 - **Run agents one at a time** - Don't run multiple agents in parallel to avoid branch conflicts

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,3 +1,4 @@
+import { View, StyleSheet } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -45,6 +46,7 @@ const AppContent = () => {
       screenOptions={{
         headerShown: false,
         contentStyle: { backgroundColor: theme.colors.background },
+        navigationBarColor: theme.colors.background,
       }}
     />
   );
@@ -75,17 +77,23 @@ const AuthGate = () => {
 };
 
 const RootLayoutNav = () => {
-  const { effectiveMode } = useThemeContext();
+  const { theme, effectiveMode } = useThemeContext();
 
   return (
-    <>
+    <View style={[styles.root, { backgroundColor: theme.colors.background }]}>
       <StatusBar style={effectiveMode === 'dark' ? 'light' : 'dark'} />
       <AuthProvider>
         <AuthGate />
       </AuthProvider>
-    </>
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});
 
 const RootLayout = () => {
   return (


### PR DESCRIPTION
## Summary
Additional fix for white flash during navigation - the previous fix with `contentStyle` wasn't sufficient.

- Wrap `RootLayoutNav` in a View with themed background color
- Add `navigationBarColor` to Stack screenOptions (Android)
- Update CLAUDE.md to enforce always creating branches for changes

## Root Cause
The white flash was caused by the underlying container being white during screen transition animations. While `contentStyle` sets the Stack container background, wrapping the entire root in a themed View ensures there's never a white surface visible.

## Test Plan
- [ ] Navigate Home → Prospect detail - no white flash
- [ ] Navigate Prospect → Traits - no white flash
- [ ] Navigate back from Traits - no white flash
- [ ] Test in dark mode as well

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)