### PR TITLE
Navigate to prospect detail after adding

### DIFF
--- a/src/app/prospect/add.tsx
+++ b/src/app/prospect/add.tsx
@@ -105,14 +105,14 @@ const AddProspectScreen = () => {
 
     setIsSubmitting(true);
     try {
-      await addProspect({
+      const id = await addProspect({
         name: name.trim(),
         photoUri,
         howWeMet,
         notes: notes.trim() || undefined,
         hasMetInPerson: hasMetInPerson!,
       });
-      router.back();
+      router.replace(`/prospect/${id}`);
     } catch (error) {
       console.error('Error adding prospect:', error);
       Alert.alert(tc('Error'), tc('Failed to add prospect. Please try again.'));


### PR DESCRIPTION
Closes #85

## Summary
- After adding a new prospect, navigate to their detail screen instead of going back to the prospect list
- Changed `router.back()` to `router.replace(`/prospect/${id}`)` in the add prospect submit handler

## Test plan
- [ ] Add a new prospect and verify you land on their detail screen
- [ ] Verify the back button from the detail screen returns to the prospect list (not the add form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)