### PR TITLE
Add onSettled to toggle category mutation

### DIFF
--- a/src/hooks/useAttributeMutations.ts
+++ b/src/hooks/useAttributeMutations.ts
@@ -168,13 +168,8 @@ export const useAttributeMutations = () => {
       );
       console.error('Toggle category error:', error);
     },
-    onSuccess: ({ attributeId, newCategory }) => {
-      queryClient.setQueryData<Attribute[]>(
-        queryKeys.attributes.list(),
-        (old) => old?.map((a) =>
-          a.id === attributeId ? { ...a, category: newCategory } : a
-        )
-      );
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.attributes.list() });
       queryClient.invalidateQueries({ queryKey: queryKeys.prospects.all });
     },
   });


### PR DESCRIPTION
Closes #135

## Summary
- Replaced `onSuccess` with `onSettled` on the `toggleCategoryMutation`, matching the pattern used by all other attribute mutations (create, updateCategory, reorder, delete)
- `onSettled` invalidates both the attributes and prospects queries after the mutation completes (success or error), ensuring the cache always syncs with Firestore
- The previous `onSuccess` handler only invalidated prospects and redundantly set the query data — it was the only mutation missing the standard `onSettled` invalidation

## Context
PR #136 fixed the root cause (mutationFn reading from cache after optimistic update), but the toggle mutation was still missing the `onSettled` safety net that ensures cache-server consistency. This is the belt-and-suspenders fix.

## Test plan
- [ ] Force-close and reopen the app to apply OTA update
- [ ] Toggle an attribute between desired/dealbreaker in Settings > Attributes
- [ ] Verify the toggle persists after navigating away and back
- [ ] Toggle an attribute during onboarding dealbreakers step
- [ ] Verify no error alerts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)